### PR TITLE
Added setting for adding cms pages to navigation menu

### DIFF
--- a/app/code/community/JR/CleverCms/Model/Observer.php
+++ b/app/code/community/JR/CleverCms/Model/Observer.php
@@ -39,13 +39,15 @@ class JR_CleverCms_Model_Observer
             $this->_addHomePageToMenu($menu, $block, true);
         }
 
-        $this->_addCmsPagesToMenu(
-            $this->_getChildren($this->getCmsRootPage()), $menu, $block, true
-        );
+        if (Mage::getStoreConfigFlag('cms/clever/show_cms_page_links')) {
+            $this->_addCmsPagesToMenu(
+                $this->_getChildren($this->getCmsRootPage()), $menu, $block, true
+            );
 
-        $this->_addCmsPagesToMenu(
-            $this->_getChildren($this->getCmsRootPage(0)), $menu, $block, true
-        );
+            $this->_addCmsPagesToMenu(
+                $this->_getChildren($this->getCmsRootPage(0)), $menu, $block, true
+            );
+        }
     }
 
 

--- a/app/code/community/JR/CleverCms/etc/config.xml
+++ b/app/code/community/JR/CleverCms/etc/config.xml
@@ -156,4 +156,11 @@
             </modules>
         </translate>
     </adminhtml>
+    <default>
+        <cms>
+            <clever>
+                <show_cms_page_links>1</show_cms_page_links>
+            </clever>
+        </cms>
+    </default>
 </config>

--- a/app/code/community/JR/CleverCms/etc/system.xml
+++ b/app/code/community/JR/CleverCms/etc/system.xml
@@ -20,6 +20,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_homepage_link>
+                        <show_cms_page_links translate="label" module="jr_clevercms">
+                            <label>Show CMS Page Links in Navigation Menu</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>15</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </show_cms_page_links>
                         <permissions_enabled translate="label" module="jr_clevercms">
                             <label>Enable Permissions</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
I can imagine there are more projects like the one I just did, in which I didn't need the CMS pages in the navigation menu at all because I show the links elsewhere on the page. The setting defaults to `true` to maintain backward compatibility.
